### PR TITLE
expose further raw token responses

### DIFF
--- a/src/tokenDefinitions.ts
+++ b/src/tokenDefinitions.ts
@@ -19,6 +19,7 @@ export class DefinitionOfFungibleTokenOnNetwork {
     canWipe: boolean = false;
     canAddSpecialRoles: boolean = false;
     assets: Record<string, any> = {};
+    rawResponse: any = {};
 
     static fromApiHttpResponse(payload: any): DefinitionOfFungibleTokenOnNetwork {
         let result = new DefinitionOfFungibleTokenOnNetwork();
@@ -38,6 +39,7 @@ export class DefinitionOfFungibleTokenOnNetwork {
         result.canFreeze = payload.canFreeze || false;
         result.canWipe = payload.canWipe || false;
         result.assets = payload.assets || {};
+        result.rawResponse = payload;
 
         return result;
     }
@@ -86,6 +88,7 @@ export class DefinitionOfTokenCollectionOnNetwork {
     canAddSpecialRoles: boolean = false;
     canTransferNftCreateRole: boolean = false;
     canCreateMultiShard: boolean = false;
+    rawResponse: any = {};
 
     static fromApiHttpResponse(payload: any): DefinitionOfTokenCollectionOnNetwork {
         let result = new DefinitionOfTokenCollectionOnNetwork();
@@ -100,6 +103,7 @@ export class DefinitionOfTokenCollectionOnNetwork {
         result.canFreeze = payload.canFreeze || false;
         result.canWipe = payload.canWipe || false;
         result.canTransferNftCreateRole = payload.canTransferNftCreateRole || false;
+        result.rawResponse = payload;
 
         return result;
     }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -32,6 +32,7 @@ export class NonFungibleTokenOfAccountOnNetwork {
     royalties: BigNumber = new BigNumber(0);
     assets: string[] = [];
     balance: BigNumber = new BigNumber(0);
+    rawResponse: any = {};
 
     constructor(init?: Partial<NonFungibleTokenOfAccountOnNetwork>) {
         Object.assign(this, init);
@@ -82,6 +83,7 @@ export class NonFungibleTokenOfAccountOnNetwork {
         result.royalties = new BigNumber(payload.royalties || 0);
         result.assets = payload.assets || [];
         result.balance = new BigNumber(payload.balance || 0);
+        result.rawResponse = payload;
 
         return result;
     }


### PR DESCRIPTION
Continuing to expose 'raw responses' similarly to what has previously been done for e.g. FungibleTokenOfAccountOnNetwork