### PR TITLE
Added a TransactionEventData class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-network-providers",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-network-providers",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "axios": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-network-providers",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "author": "MultiversX",

--- a/src/providers.dev.net.spec.ts
+++ b/src/providers.dev.net.spec.ts
@@ -193,6 +193,26 @@ describe("test network providers on devnet: Proxy and API", function () {
         proxyResponse.hyperblockHash = "";
     }
 
+    it.only("should have the same response for transactions with events", async function () {
+        const hash = "c451566a6168e38d2980fcb83d4ea154f78d53f7abf3264dd51c2c7c585671aa";
+
+        let apiResponse = await apiProvider.getTransaction(hash);
+        let proxyResponse = await proxyProvider.getTransaction(hash);
+
+        assert.exists(apiResponse.logs);
+        assert.exists(proxyResponse.logs);
+        assert.exists(apiResponse.logs.events)
+        assert.exists(proxyResponse.logs.events)
+        assert.equal(apiResponse.logs.events[0].topics[0].hex(), "5745474c442d643763366262")
+        assert.equal(apiResponse.logs.events[0].topics[1].hex(), "")
+        assert.equal(apiResponse.logs.events[0].topics[2].hex(), "0de0b6b3a7640000")
+        assert.equal(apiResponse.logs.events[0].topics[3].hex(), "00000000000000000500e01285f90311fb5925a9623a1dc62eee41fa8c869a0d")
+        assert.equal(proxyResponse.logs.events[0].topics[0].hex(), "5745474c442d643763366262")
+        assert.equal(proxyResponse.logs.events[0].topics[1].hex(), "")
+        assert.equal(proxyResponse.logs.events[0].topics[2].hex(), "0de0b6b3a7640000")
+        assert.equal(proxyResponse.logs.events[0].topics[3].hex(), "00000000000000000500e01285f90311fb5925a9623a1dc62eee41fa8c869a0d")
+    });
+
     // TODO: Fix differences of "tx.status", then enable this test.
     it.skip("should have same response for getTransactionStatus()", async function () {
         this.timeout(20000);

--- a/src/transactionEvents.ts
+++ b/src/transactionEvents.ts
@@ -5,7 +5,7 @@ export class TransactionEvent {
     address: IAddress = new Address("");
     identifier: string = "";
     topics: TransactionEventTopic[] = [];
-    data_payload: TransactionEventData = new TransactionEventData(Buffer.from("", "utf8"));
+    dataPayload: TransactionEventData = new TransactionEventData(Buffer.from("", "utf8"));
     data: string = "";
 
     constructor(init?: Partial<TransactionEvent>) {
@@ -24,7 +24,7 @@ export class TransactionEvent {
         result.topics = (responsePart.topics || []).map(topic => new TransactionEventTopic(topic));
 
         const raw_data = Buffer.from(responsePart.data || "", "base64")
-        result.data_payload = new TransactionEventData(raw_data);
+        result.dataPayload = new TransactionEventData(raw_data);
         result.data = raw_data.toString();
 
         return result;

--- a/src/transactionEvents.ts
+++ b/src/transactionEvents.ts
@@ -5,6 +5,7 @@ export class TransactionEvent {
     address: IAddress = new Address("");
     identifier: string = "";
     topics: TransactionEventTopic[] = [];
+    data_payload: TransactionEventData = new TransactionEventData(Buffer.from("", "utf8"));
     data: string = "";
 
     constructor(init?: Partial<TransactionEvent>) {
@@ -21,8 +22,11 @@ export class TransactionEvent {
         result.address = new Address(responsePart.address);
         result.identifier = responsePart.identifier || "";
         result.topics = (responsePart.topics || []).map(topic => new TransactionEventTopic(topic));
-        result.data = Buffer.from(responsePart.data || "", "base64").toString();
-        
+
+        const raw_data = Buffer.from(responsePart.data || "", "base64")
+        result.data_payload = new TransactionEventData(raw_data);
+        result.data = raw_data.toString();
+
         return result;
     }
 
@@ -32,6 +36,26 @@ export class TransactionEvent {
 
     getLastTopic(): TransactionEventTopic {
         return this.topics[this.topics.length - 1];
+    }
+}
+
+export class TransactionEventData {
+    private readonly raw: Buffer;
+
+    constructor(data: Buffer) {
+        this.raw = data;
+    }
+
+    toString(): string {
+        return this.raw.toString("utf8");
+    }
+
+    hex(): string {
+        return this.raw.toString("hex");
+    }
+
+    valueOf(): Buffer {
+        return this.raw;
     }
 }
 

--- a/src/transactionEvents.ts
+++ b/src/transactionEvents.ts
@@ -23,9 +23,9 @@ export class TransactionEvent {
         result.identifier = responsePart.identifier || "";
         result.topics = (responsePart.topics || []).map(topic => new TransactionEventTopic(topic));
 
-        const raw_data = Buffer.from(responsePart.data || "", "base64")
-        result.dataPayload = new TransactionEventData(raw_data);
-        result.data = raw_data.toString();
+        const rawData = Buffer.from(responsePart.data || "", "base64")
+        result.dataPayload = new TransactionEventData(rawData);
+        result.data = rawData.toString();
 
         return result;
     }


### PR DESCRIPTION
The data field of a `TransactionEvent` couldn't always be decoded, so now we have a `TransactionEventData` class that stores the raw value.

In the `TransactionEvent` class we've kept the data field for compatibility reasons, but the `dataPayload` field should be used. In the future the field will be removed and the new field will take it's place.