### PR TITLE
Fix unit test

### DIFF
--- a/src/providers.dev.net.spec.ts
+++ b/src/providers.dev.net.spec.ts
@@ -27,12 +27,12 @@ describe("test network providers on devnet: Proxy and API", function () {
         let apiResponse = await apiProvider.getNetworkStatus();
         let proxyResponse = await proxyProvider.getNetworkStatus();
 
-        assert.equal(apiResponse.CurrentRound, proxyResponse.CurrentRound);
         assert.equal(apiResponse.EpochNumber, proxyResponse.EpochNumber);
         assert.equal(apiResponse.NonceAtEpochStart, proxyResponse.NonceAtEpochStart);
         assert.equal(apiResponse.RoundAtEpochStart, proxyResponse.RoundAtEpochStart);
         assert.equal(apiResponse.RoundsPerEpoch, proxyResponse.RoundsPerEpoch);
         // done this way because the nonces may change until both requests are executed
+        assert.approximately(apiResponse.CurrentRound, proxyResponse.CurrentRound, 1);
         assert.approximately(apiResponse.HighestFinalNonce, proxyResponse.HighestFinalNonce, 1);
         assert.approximately(apiResponse.Nonce, proxyResponse.Nonce, 1);
         assert.approximately(apiResponse.NoncesPassedInCurrentEpoch, proxyResponse.NoncesPassedInCurrentEpoch, 1);


### PR DESCRIPTION
There were times when the tests we're running at round change, so the first provider would get the request completed and the second provider would get the request completed in the next round. Now using `assert.approximately()` to allow a round difference of max 1 round.