### PR TITLE
WIP - Breaking change: decouple from "axios"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,17 @@
 {
   "name": "@multiversx/sdk-network-providers",
-  "version": "2.2.0",
+  "version": "3.0.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-network-providers",
-      "version": "2.2.0",
+      "version": "3.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "1.6.1",
         "bech32": "1.1.4",
         "bignumber.js": "9.0.1",
-        "buffer": "6.0.3",
-        "json-bigint": "1.0.0"
+        "buffer": "6.0.3"
       },
       "devDependencies": {
         "@types/assert": "1.4.6",
@@ -21,7 +19,9 @@
         "@types/mocha": "9.1.0",
         "@types/node": "13.13.2",
         "assert": "2.0.0",
+        "axios": "1.6.2",
         "chai": "4.2.0",
+        "json-bigint": "1.0.0",
         "mocha": "9.2.2",
         "ts-node": "9.1.1",
         "tslint": "6.1.3",
@@ -247,7 +247,8 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
@@ -262,9 +263,10 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
-      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -523,6 +525,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -615,6 +618,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -715,6 +719,7 @@
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
       "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -743,6 +748,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -1169,6 +1175,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -1238,6 +1245,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1246,6 +1254,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -1468,7 +1477,8 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -2272,7 +2282,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "available-typed-arrays": {
       "version": "1.0.5",
@@ -2281,9 +2292,10 @@
       "dev": true
     },
     "axios": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
-      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "dev": true,
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -2466,6 +2478,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -2533,7 +2546,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
     },
     "diff": {
       "version": "5.0.0",
@@ -2599,7 +2613,8 @@
     "follow-redirects": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "dev": true
     },
     "for-each": {
       "version": "0.3.3",
@@ -2614,6 +2629,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -2907,6 +2923,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
       "requires": {
         "bignumber.js": "^9.0.0"
       }
@@ -2957,12 +2974,14 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -3117,7 +3136,8 @@
     "proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "randombytes": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-network-providers",
-  "version": "2.2.0",
+  "version": "3.0.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "author": "MultiversX",
@@ -13,11 +13,9 @@
   "types": "out/index.d.js",
   "packages": {},
   "dependencies": {
-    "axios": "1.6.1",
     "bech32": "1.1.4",
     "bignumber.js": "9.0.1",
-    "buffer": "6.0.3",
-    "json-bigint": "1.0.0"
+    "buffer": "6.0.3"
   },
   "devDependencies": {
     "@types/assert": "1.4.6",
@@ -25,7 +23,9 @@
     "@types/mocha": "9.1.0",
     "@types/node": "13.13.2",
     "assert": "2.0.0",
+    "axios": "1.6.2",
     "chai": "4.2.0",
+    "json-bigint": "1.0.0",
     "mocha": "9.2.2",
     "ts-node": "9.1.1",
     "tslint": "6.1.3",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,17 +1,5 @@
 import { IPagination } from "./interface";
 
-const JSONbig = require("json-bigint")({ constructorAction: 'ignore' });
-
-export const defaultAxiosConfig = {
-    timeout: 5000,
-    // See: https://github.com/axios/axios/issues/983 regarding transformResponse
-    transformResponse: [
-        function (data: any) {
-            return JSONbig.parse(data);
-        }
-    ]
-};
-
 export const defaultPagination: IPagination = {
     from: 0,
     size: 100

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -133,3 +133,8 @@ export interface ITransaction {
 }
 
 export interface IAddress { bech32(): string; }
+
+export interface IHttpProvider {
+    get(url: string): Promise<any>;
+    post(url: string, payload: any): Promise<any>;
+}

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -135,6 +135,6 @@ export interface ITransaction {
 export interface IAddress { bech32(): string; }
 
 export interface IHttpProvider {
-    get(url: string): Promise<any>;
-    post(url: string, payload: any): Promise<any>;
+    get<T = any>(url: string): Promise<T>;
+    post<T = any>(url: string, payload: any): Promise<T>;
 }

--- a/src/proxyNetworkProvider.ts
+++ b/src/proxyNetworkProvider.ts
@@ -1,11 +1,9 @@
-import axios, { AxiosRequestConfig } from "axios";
 import { AccountOnNetwork, GuardianData } from "./accounts";
-import { defaultAxiosConfig } from "./config";
 import { EsdtContractAddress } from "./constants";
 import { ContractQueryRequest } from "./contractQueryRequest";
 import { ContractQueryResponse } from "./contractQueryResponse";
 import { ErrContractQuery, ErrNetworkProvider } from "./errors";
-import { IAddress, IContractQuery, INetworkProvider, IPagination, ITransaction } from "./interface";
+import { IAddress, IContractQuery, IHttpProvider, INetworkProvider, IPagination, ITransaction } from "./interface";
 import { NetworkConfig } from "./networkConfig";
 import { NetworkGeneralStatistics } from "./networkGeneralStatistics";
 import { NetworkStake } from "./networkStake";
@@ -17,12 +15,12 @@ import { TransactionStatus } from "./transactionStatus";
 
 // TODO: Find & remove duplicate code between "ProxyNetworkProvider" and "ApiNetworkProvider".
 export class ProxyNetworkProvider implements INetworkProvider {
-    private url: string;
-    private config: AxiosRequestConfig;
+    private baseUrl: string;
+    private httpProvider: IHttpProvider;
 
-    constructor(url: string, config?: AxiosRequestConfig) {
-        this.url = url;
-        this.config = { ...defaultAxiosConfig, ...config };
+    constructor(options: { baseUrl: string, httpProvider: IHttpProvider }) {
+        this.baseUrl = options.baseUrl;
+        this.httpProvider = options.httpProvider;
     }
 
     async getNetworkConfig(): Promise<NetworkConfig> {
@@ -194,30 +192,22 @@ export class ProxyNetworkProvider implements INetworkProvider {
     }
 
     private async doGet(resourceUrl: string): Promise<any> {
-        let url = `${this.url}/${resourceUrl}`;
+        const url = `${this.baseUrl}/${resourceUrl}`;
 
         try {
-            let response = await axios.get(url, this.config);
-            let payload = response.data.data;
-            return payload;
+            const response = await this.httpProvider.get(url);
+            return response.data;
         } catch (error) {
             this.handleApiError(error, resourceUrl);
         }
     }
 
     private async doPost(resourceUrl: string, payload: any): Promise<any> {
-        let url = `${this.url}/${resourceUrl}`;
+        const url = `${this.baseUrl}/${resourceUrl}`;
 
         try {
-            let response = await axios.post(url, payload, {
-                ...this.config,
-                headers: {
-                    "Content-Type": "application/json",
-                    ...this.config.headers,
-                },
-            });
-            let responsePayload = response.data.data;
-            return responsePayload;
+            const response = await this.httpProvider.post(url, payload);
+            return response.data;
         } catch (error) {
             this.handleApiError(error, resourceUrl);
         }


### PR DESCRIPTION
While `axios` is a great library, we'd like to decouple `sdk-network-providers` from it - so that issues related to `axios` do not impact this package anymore.

**Breaking change:** the constructors `ApiNetworkProvider` and `ProxyNetworkProvider` have been altered (see snippet below).

Client code would now be responsible with providing a `httpProvider` when instantiating `ApiNetworkProvider` or `ProxyNetworkProvider`.

A `httpProvider` must satisfy the following interface:

```
export interface IHttpProvider {
    get(url: string): Promise<any>;
    post(url: string, payload: any): Promise<any>;
    // TBD: error handling
}
```

Such a `httpProvider` can be power, indeed, by `axios`. For example:

```
const apiProvider: INetworkProvider = new ApiNetworkProvider({
    baseUrl: "https://devnet-api.multiversx.com",
    httpProvider: createHttpProvider()
});

const proxyProvider: INetworkProvider = new ProxyNetworkProvider({
    baseUrl: "https://devnet-gateway.multiversx.com",
    httpProvider: createHttpProvider()
});

// Depends on:
// - https://www.npmjs.com/package/axios
// - https://www.npmjs.com/package/json-bigint
function createHttpProvider() {
    const axios = require("axios").default;
    const jsonBig = require("json-bigint")({ constructorAction: "ignore" });

    const axiosConfig = {
        timeout: 10000,
        // See: https://github.com/axios/axios/issues/983 regarding transformResponse
        // Very important, to properly handle responses bearing big integers.
        transformResponse: [
            function (data: any) {
                return jsonBig.parse(data);
            }
        ],
        headers: {
            "Content-Type": "application/json"
        }
    };

    return {
        async get(url: string) {
            return (await axios.get(url, axiosConfig)).data;
        },
        async post(url: string, payload: any) {
            return (await axios.post(url, payload, axiosConfig)).data;
        }
    };
}
```

This design change also allows the code that depends on `ApiNetworkProvider` or `ProxyNetworkProvider` to be tested in a less complex fashion - since passing a mock `IHttpProvider` would be much simpler than using special axios mock adapters.