### PR TITLE
Simplify ProxyNetworkProvider.getTransaction(): ignore parameter withProcessStatus, consider it TRUE always

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-network-providers",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-network-providers",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "MIT",
       "dependencies": {
         "bech32": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-network-providers",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "author": "MultiversX",

--- a/src/proxyNetworkProvider.ts
+++ b/src/proxyNetworkProvider.ts
@@ -103,7 +103,7 @@ export class ProxyNetworkProvider implements INetworkProvider {
         return tokenData;
     }
 
-    async getTransaction(txHash: string, _: boolean): Promise<TransactionOnNetwork> {
+    async getTransaction(txHash: string, _?: boolean): Promise<TransactionOnNetwork> {
         const url = this.buildUrlWithQueryParameters(`transaction/${txHash}`, { withResults: "true" });
         const [data, status] = await Promise.all([this.doGetGeneric(url), this.getTransactionStatus(txHash)]);
         return TransactionOnNetwork.fromProxyHttpResponse(txHash, data.transaction, status);

--- a/src/proxyNetworkProvider.ts
+++ b/src/proxyNetworkProvider.ts
@@ -103,21 +103,10 @@ export class ProxyNetworkProvider implements INetworkProvider {
         return tokenData;
     }
 
-    async getTransaction(txHash: string, withProcessStatus?: boolean): Promise<TransactionOnNetwork> {
-        let processStatusPromise: Promise<TransactionStatus> | undefined;
-
-        if (withProcessStatus === true) {
-            processStatusPromise = this.getTransactionStatus(txHash);
-        }
-
-        let url = this.buildUrlWithQueryParameters(`transaction/${txHash}`, { withResults: "true" });
-        let response = await this.doGetGeneric(url);
-
-        if (processStatusPromise) {
-            const processStatus = await processStatusPromise;
-            return TransactionOnNetwork.fromProxyHttpResponse(txHash, response.transaction, processStatus);
-        }
-        return TransactionOnNetwork.fromProxyHttpResponse(txHash, response.transaction);
+    async getTransaction(txHash: string, _: boolean): Promise<TransactionOnNetwork> {
+        const url = this.buildUrlWithQueryParameters(`transaction/${txHash}`, { withResults: "true" });
+        const [data, status] = await Promise.all([this.doGetGeneric(url), this.getTransactionStatus(txHash)]);
+        return TransactionOnNetwork.fromProxyHttpResponse(txHash, data.transaction, status);
     }
 
     async getTransactionStatus(txHash: string): Promise<TransactionStatus> {


### PR DESCRIPTION
Non-breaking change.

Due to this simplification, the following workaround will not be needed anymore:
https://docs.multiversx.com/sdk-and-tools/sdk-js/sdk-js-cookbook-v13/#wait-for-transaction-completion

